### PR TITLE
Remove composer classmap-authoritative config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,5 @@
     },
     "autoload-dev": {
         "psr-4": { "PHPExperts\\PHPLOCAnalyzer\\Tests\\" : "tests/" }
-    },
-    "config": {
-        "classmap-authoritative": true
     }
 }


### PR DESCRIPTION
# Changed log

- To avoid `Deprecation Notice: Class PHPExperts\PHPLOCAnalyzer\Tests\PHPLOCAnalyzerTestCase located in ./tests/PHPLOCAnalyzerTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/lee/composer.phar/src/Composer/Autoload/ClassMapGenerator.php:201` issue, it's nice to remove `classmap-authoritative` config.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/phplocanalyzer/1)
<!-- Reviewable:end -->
